### PR TITLE
V0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+## 0.6.0 (2022-11-27)
+
+#### More like Vite, loose syntax!
+
+**0.6.x**
+
+```js
+const { foo } = require('foo')
+↓
+const { foo } = __CJS__import__0__.default || __CJS__import__0__
+```
+
+```js
+const bar = require('bar')
+↓
+import * as __CJS__import__0__ from '/bar'
+const bar = __CJS__import__0__.default || __CJS__import__0__
+```
+
+**0.5.x**
+
+```js
+const { foo } = require('foo')
+↓
+import { foo } from 'foo'
+```
+
+```js
+const bar = require('bar')
+↓
+import * as __CJS__import__0__ from '/bar'
+const bar = __CJS__import__0__
+```
+
+#### Main commit
+
+- eda5464 v0.6.0
+- b5f7089 refactor!: loose syntax convert #15
+
 ## 0.5.3 (2022-10-16)
 
 - ee0a882 `src-output` -> `__snapshots__`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-commonjs",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "A pure JavaScript implementation of CommonJs",
   "type": "module",
   "main": "index.js",

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -120,6 +120,12 @@ function findTopLevelScope(ancestors: AcornNode[]): AcornNode | undefined {
     return arr.find(e => e.type === TopScopeType.ExpressionStatement)
   }
 
+  // TODO(#15): Loose conversion of `exports` is required to get elegant import statements, vice versa.
+  //            需要松散的 exports 转换，才能得到优雅的 import 语句，反之亦然。
+  // 🚨-①: Vite also does the same. All statements are imported as `*`, which is simple and easy to implement. :)
+  //       Vite 也是这么做的，所有语句都以 * 导入，即简单又好实现。
+  return
+
   // At present, "ancestors" contains only one depth of "MemberExpression"
   if (/Program,VariableDeclaration,VariableDeclarator,(MemberExpression,)?CallExpression$/.test(ances)) {
     // const bar = require('foo').bar

--- a/src/generate-import.ts
+++ b/src/generate-import.ts
@@ -72,17 +72,19 @@ export function generateImport(analyzed: Analyzed) {
          ${'^'.repeat(codeSnippets.length)}`)
     }
 
-    if (topScopeNode) {
+    if (/* 🚨-① topScopeNode */false) {
       // ①(🎯)
 
+      // @ts-ignore
       switch (topScopeNode.type) {
         case TopScopeType.ExpressionStatement:
-          // TODO: With members
+          // TODO: With members - e.g. `require().foo`
           impt.importee = `import '${requireId}'`
           break
 
         case TopScopeType.VariableDeclaration:
           // TODO: Multiple declaration
+          // @ts-ignore
           const VariableDeclarator = topScopeNode.declarations[0]
           const { /* L-V */id, /* R-V */init } = VariableDeclarator as AcornNode
 
@@ -93,6 +95,7 @@ export function generateImport(analyzed: Analyzed) {
           } else if (id.type === 'ObjectPattern') {
             LV = []
             for (const { key, value } of id.properties) {
+              // @ts-ignore
               LV.push({ key: key.name, value: value.name })
             }
           } else {
@@ -149,7 +152,7 @@ export function generateImport(analyzed: Analyzed) {
 
       // This is probably less accurate but is much cheaper than a full AST parse.
       impt.importee = `import * as ${importName} from '${requireId}'`
-      impt.importName = importName
+      impt.importName = `${importName}.default || ${importName}` // Loose
     }
 
     imports.push(impt)


### PR DESCRIPTION
## 0.6.0 (2022-11-27)

#### More like Vite, loose syntax!

**0.6.x**

```js
const { foo } = require('foo')
↓
const { foo } = __CJS__import__0__.default || __CJS__import__0__
```

```js
const bar = require('bar')
↓
import * as __CJS__import__0__ from '/bar'
const bar = __CJS__import__0__.default || __CJS__import__0__
```

**0.5.x**

```js
const { foo } = require('foo')
↓
import { foo } from 'foo'
```

```js
const bar = require('bar')
↓
import * as __CJS__import__0__ from '/bar'
const bar = __CJS__import__0__
```