### PR TITLE
V0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.6.1 (2022-12-10)
+
+- b163947 v0.6.1
+- 232042f feat: cjs examples
+- 4ad7a9b fix: `var` instead `const` #17
+
+```diff
+- const module = { exports: {} }; const exports = module.exports;
++ var module = { exports: {} }; var exports = module.exports;
+```
+
 ## 0.6.0 (2022-11-27)
 
 #### More like Vite, loose syntax!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-commonjs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A pure JavaScript implementation of CommonJs",
   "type": "module",
   "main": "index.js",

--- a/src/generate-export.ts
+++ b/src/generate-export.ts
@@ -31,7 +31,7 @@ export function generateExport(analyzed: Analyzed): ExportsRuntime | null {
   }
 
   return {
-    polyfill: 'const module = { exports: {} }; const exports = module.exports;',
+    polyfill: 'var module = { exports: {} }; var exports = module.exports;',
     exportDeclaration: `
 ${membersDeclaration.join(';\n')};
 export {

--- a/test/__snapshots__/cjs.js
+++ b/test/__snapshots__/cjs.js
@@ -1,0 +1,13 @@
+/* export-runtime-S */ var module = { exports: {} }; var exports = module.exports; /* export-runtime-E */if (typeof exports !== 'undefined') {
+  if (typeof module !== 'undefined' && module.exports) {
+    exports = module.exports = {
+      cjs: 'cjs',
+    }
+  }
+}
+/* export-statement-S */
+const __CJS__export_default__ = (module.exports == null ? {} : module.exports).default || module.exports;
+export {
+  __CJS__export_default__ as default,
+}
+/* export-statement-E */

--- a/test/__snapshots__/exports.js
+++ b/test/__snapshots__/exports.js
@@ -1,5 +1,10 @@
-/* export-runtime-S */ const module = { exports: {} }; const exports = module.exports; /* export-runtime-E */
-import { hello, world } from './dynamic';
+/* export-runtime-S */ var module = { exports: {} }; var exports = module.exports; /* export-runtime-E *//* import-hoist-S */ import * as __CJS__import__0__ from './dynamic'; /* import-hoist-E */
+const { hello, world } = __CJS__import__0__.default || __CJS__import__0__
+
+// ❌ `exports` exported members are dynamic.
+// import { cjs } from './cjs'
+// ✅
+import cjs from './cjs'
 
 exports.msg = `
 [foo.js]
@@ -8,6 +13,13 @@ const { hello, world } = require('./dynamic')
 
 hello: ${hello}
 world: ${world}
+
+<hr/>
+[cjs.js]
+
+import cjs from './cjs'
+
+cjs: ${JSON.stringify(cjs)}
 `
 /* export-statement-S */
 const __CJS__export_msg__ = (module.exports == null ? {} : module.exports).msg;

--- a/test/__snapshots__/main.ts
+++ b/test/__snapshots__/main.ts
@@ -1,6 +1,11 @@
-import { msg as message } from './exports';
+/* import-hoist-S */ import * as __CJS__import__0__ from './exports'; /* import-hoist-E */const { msg: message } = __CJS__import__0__.default || __CJS__import__0__;
+import cjs from "./cjs";
 document.querySelector("#app").innerHTML = `
   <pre>
     ${message}
+  </pre>
+  <hr/>
+  <pre>
+    ${cjs.cjs}
   </pre>
 `;

--- a/test/__snapshots__/module-exports/hello.cjs
+++ b/test/__snapshots__/module-exports/hello.cjs
@@ -1,4 +1,4 @@
-/* export-runtime-S */ const module = { exports: {} }; const exports = module.exports; /* export-runtime-E */
+/* export-runtime-S */ var module = { exports: {} }; var exports = module.exports; /* export-runtime-E */
 module.exports = 'module-exports/hello.cjs'
 /* export-statement-S */
 const __CJS__export_default__ = (module.exports == null ? {} : module.exports).default || module.exports;

--- a/test/__snapshots__/module-exports/world.cjs
+++ b/test/__snapshots__/module-exports/world.cjs
@@ -1,4 +1,4 @@
-/* export-runtime-S */ const module = { exports: {} }; const exports = module.exports; /* export-runtime-E */
+/* export-runtime-S */ var module = { exports: {} }; var exports = module.exports; /* export-runtime-E */
 module.exports = 'module-exports/world.cjs'
 /* export-statement-S */
 const __CJS__export_default__ = (module.exports == null ? {} : module.exports).default || module.exports;

--- a/test/src/cjs.js
+++ b/test/src/cjs.js
@@ -1,0 +1,7 @@
+if (typeof exports !== 'undefined') {
+  if (typeof module !== 'undefined' && module.exports) {
+    exports = module.exports = {
+      cjs: 'cjs',
+    }
+  }
+}

--- a/test/src/exports.js
+++ b/test/src/exports.js
@@ -1,6 +1,11 @@
 
 const { hello, world } = require('./dynamic')
 
+// ❌ `exports` exported members are dynamic.
+// import { cjs } from './cjs'
+// ✅
+import cjs from './cjs'
+
 exports.msg = `
 [foo.js]
 
@@ -8,4 +13,11 @@ const { hello, world } = require('./dynamic')
 
 hello: ${hello}
 world: ${world}
+
+<hr/>
+[cjs.js]
+
+import cjs from './cjs'
+
+cjs: ${JSON.stringify(cjs)}
 `

--- a/test/src/main.ts
+++ b/test/src/main.ts
@@ -1,7 +1,14 @@
 const { msg: message } = require('./exports')
 
+// import { cjs } from './cjs'
+import cjs from './cjs'
+
 document.querySelector('#app')!.innerHTML = `
   <pre>
     ${message}
+  </pre>
+  <hr/>
+  <pre>
+    ${cjs.cjs}
   </pre>
 `


### PR DESCRIPTION
## 0.6.1 (2022-12-10)

- b163947 v0.6.1
- 232042f feat: cjs examples
- 4ad7a9b fix: `var` instead `const` #17

```diff
- const module = { exports: {} }; const exports = module.exports;
+ var module = { exports: {} }; var exports = module.exports;
```
