### PR TITLE
enhancement: support node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export default {
 
 ```ts
 export interface Options {
-  filter?: (id: string) => false | undefined
+  filter?: (id: string) => boolean | undefined
   dynamic?: {
     /**
      * 1. `true` - Match all possibilities as much as possible, more like `webpack`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@ export default {
 
 ```ts
 export interface Options {
-  filter?: (id: string) => false | undefined
+  filter?: (id: string) => boolean | undefined
   dynamic?: {
     /**
      * 1. `true` - 尽量匹配所有可能场景, 功能更像 `webpack`

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { isCommonjs } from './utils'
 import { DynaimcRequire } from './dynamic-require'
 
 export interface Options {
-  filter?: (id: string) => false | undefined
+  filter?: (id: string) => boolean | undefined
   dynamic?: {
     /**
      * 1. `true` - Match all possibilities as much as possible, more like `webpack`
@@ -60,7 +60,7 @@ export default function commonjs(options: Options = {}): Plugin {
       })
     },
     async transform(code, id) {
-      if (/node_modules\/(?!\.vite\/)/.test(id)) return
+      if (/node_modules\/(?!\.vite\/)/.test(id) && !options.filter?.(id)) return
       if (!extensions.includes(path.extname(id))) return
       if (!isCommonjs(code)) return
       if (options.filter?.(id) === false) return


### PR DESCRIPTION
This change remains backward compatible. Normally, files in the node_modules will still not be processed unless someone explicitly return true in the `options.filter`.