### PR TITLE
V0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.4 (2024-11-21)
+
+- b1ff4b6 feat: bump vite-plugin-utils to 0.4.4 to support `.cjs`, `.cts` extension by default
+- debe58a fix: bump vite-plugin-utils to 0.4.4 for large cjs bundles #62
+
 ## 0.10.3 (2023-09-16)
 
 - e369497 chore: bump deps

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node-fetch": "^3.3.2",
     "typescript": "^5.6.2",
     "vite": "^4.4.5",
-    "vite-plugin-utils": "^0.4.4",
+    "vite-plugin-utils": "^0.4.5",
     "vitest": "^2.1.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-commonjs",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A pure JavaScript implementation of CommonJs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node-fetch": "^3.3.2",
     "typescript": "^5.6.2",
     "vite": "^4.4.5",
-    "vite-plugin-utils": "^0.4.3",
+    "vite-plugin-utils": "^0.4.4",
     "vitest": "^2.1.1"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,10 +818,10 @@ vite-plugin-dynamic-import@^1.6.0:
     fast-glob "^3.3.2"
     magic-string "^0.30.11"
 
-vite-plugin-utils@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/vite-plugin-utils/-/vite-plugin-utils-0.4.4.tgz#ae43712f121e52690b23bbe675fd4a55d9c19521"
-  integrity sha512-5Gvbw3a8KWy5OJwQB7zavTrUYL0H54HbSY77ZZMPeZVMZiEV/unpELFW/hLswnbXOJMqHyBX2s+FfoYkxD+rzA==
+vite-plugin-utils@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vite-plugin-utils/-/vite-plugin-utils-0.4.5.tgz#b6f71309b3ad36592b02ea88faf2cdbf075669ca"
+  integrity sha512-ZkKUIsNhyDNRWhp29oL96Ys0EzU4sqnNxa/z82vTLeAODDx4i4M9SjyIkDpPjiYnqRtYdjJo+eru7DTOXQ/o9A==
 
 vite@^4.4.5:
   version "4.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,10 +818,10 @@ vite-plugin-dynamic-import@^1.6.0:
     fast-glob "^3.3.2"
     magic-string "^0.30.11"
 
-vite-plugin-utils@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/vite-plugin-utils/-/vite-plugin-utils-0.4.3.tgz#5991e3c43313d08e440edb7e6ccbffe64bf64caf"
-  integrity sha512-DL6ychD1UkqFtmBY1hDj4fY+QvsNsodUENCTdO8Oer6BuwdkVCU91NAQc/JZumcelJRZDm80aUwL4DEl4GlLZw==
+vite-plugin-utils@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/vite-plugin-utils/-/vite-plugin-utils-0.4.4.tgz#ae43712f121e52690b23bbe675fd4a55d9c19521"
+  integrity sha512-5Gvbw3a8KWy5OJwQB7zavTrUYL0H54HbSY77ZZMPeZVMZiEV/unpELFW/hLswnbXOJMqHyBX2s+FfoYkxD+rzA==
 
 vite@^4.4.5:
   version "4.5.3"


### PR DESCRIPTION
## 0.10.4 (2024-11-21)

- b1ff4b6 feat: bump vite-plugin-utils to 0.4.4 to support `.cjs`, `.cts` extension by default
- debe58a fix: bump vite-plugin-utils to 0.4.4 for large cjs bundles #62